### PR TITLE
Relax cabal requirements for Heroku build

### DIFF
--- a/graph-rtce.cabal
+++ b/graph-rtce.cabal
@@ -11,13 +11,10 @@ cabal-version:       >=1.18
 executable graph-rtce
   hs-source-dirs:       src
   main-is:              Server.hs
-  build-depends:        scotty == 0.6.2, blaze-html,
-                        wai, wai-extra, warp,
-                        websockets, wai-websockets,
-                        fay, aeson,
-                        mtl, stm,
-                        containers, text, bytestring,
-                        type-eq == 0.4,
-                        base >= 4.6
+  build-depends:        scotty >= 0.6.2, blaze-html, wai, wai-extra,
+                        warp, websockets, wai-websockets, fay, aeson,
+                        mtl, stm, containers, text, bytestring,
+                        type-eq >= 0.4, base >= 4.6
   ghc-options:          -threaded -Wall -O
+  extensions:           ParallelListComp
   default-language:     Haskell2010


### PR DESCRIPTION
With these changes the Anvil build _almost_ passes. I think the Heroku environmental factors are good now and the only problem is updating this project to use new Wai Websockets stuff. Here is the error I get at the end of a mostly successful Anvil build:

``` sh
Building graph-rtce-0.0.0.0...
Preprocessing executable 'graph-rtce' for graph-rtce-0.0.0.0...
[1 of 3] Compiling Pages.Index      ( src/Pages/Index.hs, dist/build/graph-rtce/graph-rtce-tmp/Pages/Index.o )

src/Pages/Index.hs:8:1: Warning:
    Top-level binding with no type signature:
   render :: blaze-markup-0.6.1.0:Text.Blaze.Internal.MarkupM ()
[2 of 3] Compiling Types            ( src/Types.hs, dist/build/graph-rtce/graph-rtce-tmp/Types.o )
[3 of 3] Compiling Main             ( src/Server.hs, dist/build/graph-rtce/graph-rtce-tmp/Main.o )

src/Server.hs:18:40:
    Module ‘Network.Wai.Handler.WebSockets’ does not export ‘intercept’
```
