### PR TITLE
Builds on Anvil

### DIFF
--- a/graph-rtce.cabal
+++ b/graph-rtce.cabal
@@ -20,4 +20,5 @@ executable graph-rtce
                         type-eq == 0.4,
                         base >= 4.6
   ghc-options:          -threaded -Wall -O
+  extensions:           ParallelListComp
   default-language:     Haskell2010

--- a/graph-rtce.cabal
+++ b/graph-rtce.cabal
@@ -11,14 +11,10 @@ cabal-version:       >=1.18
 executable graph-rtce
   hs-source-dirs:       src
   main-is:              Server.hs
-  build-depends:        scotty >= 0.6.2, blaze-html,
-                        wai, wai-extra, warp,
-                        websockets, wai-websockets,
-                        fay, aeson,
-                        mtl, stm,
-                        containers, text, bytestring,
-                        type-eq == 0.4,
-                        base >= 4.6
+  build-depends:        scotty >= 0.6.2, blaze-html, wai, wai-extra,
+                        warp, websockets, wai-websockets, fay, aeson,
+                        mtl, stm, containers, text, bytestring,
+                        type-eq >= 0.4, base >= 4.6
   ghc-options:          -threaded -Wall -O
   extensions:           ParallelListComp
   default-language:     Haskell2010


### PR DESCRIPTION
I rebased your change with my original pull request and it successfully builds on Anvil.

Well, almost. The Haskell part is just fine, but it builds so slowly on Anvil that the slug upload request is rejected because of a time-out. The sad part is that it appears to have successfully created the Heroku build cache, but Anvil discards it because the final slug upload fails. (As a last resort I tried pushing to Heroku and guessing that the cache key is `29fd91e6-8d5f-4995-a8ac-337a65290166` but it didn't work.)

``` sh
Linking dist/build/graph-rtce/graph-rtce ...
  Cleaning any source downloads from the build cache
  Caching latest cabal sandbox
  Making GHC binaries available to Heroku command line
  Making cabal config available to Heroku command line
  Making cabal sandbox available to Heroku command line
Putting cache... done
Creating slug... done
Uploading slug... <?xml version="1.0" encoding="UTF-8"?>
<Error><Code>AccessDenied</Code><Message>Request has expired</Message><RequestId>43E01BFA0698E16C</RequestId><Expires>2014-05-24T17:12:00Z</Expires><HostId>nw+Z1fo4sBfbws/pMvNcZqRiiFf1ci1p98IgsW1NUFkqXWqpiqFyHrfFgMSQxGsF</HostId><ServerTime>2014-05-24T19:19:21Z</ServerTime></Error>
 !    Heroku client internal error.
 !    Search for help at: https://help.heroku.com
 !    Or report a bug at: https://github.com/heroku/heroku/issues/new

    Error:       invalid value for Integer(): "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Error><Code>NoSuchKey</Code><Message>The specified key does not exist.</Message><Key>exit/29fd91e6-8d5f-4995-a8ac-337a65290166</Key><RequestId>131C15189D05991C</RequestId><HostId>XkzNWI8bT9nifVbbr3BRNODxUfukvEi8MyjoyeuraFz8PYnTX4I5WU/V3EPrne1A</HostId></Error>" (ArgumentError)
    Backtrace:   /Users/j/.heroku/plugins/heroku-anvil/vendor/anvil/lib/anvil/manifest.rb:90:in `Integer'
                 /Users/j/.heroku/plugins/heroku-anvil/vendor/anvil/lib/anvil/manifest.rb:90:in `block in build'
                 /usr/local/heroku/ruby/lib/ruby/1.9.1/net/http.rb:1322:in `block (2 levels) in transport_request'
                 /usr/local/heroku/ruby/lib/ruby/1.9.1/net/http.rb:2671:in `reading_body'
                 /usr/local/heroku/ruby/lib/ruby/1.9.1/net/http.rb:1321:in `block in transport_request'
                 /usr/local/heroku/ruby/lib/ruby/1.9.1/net/http.rb:1316:in `catch'
                 /usr/local/heroku/ruby/lib/ruby/1.9.1/net/http.rb:1316:in `transport_request'
                 /usr/local/heroku/ruby/lib/ruby/1.9.1/net/http.rb:1293:in `request'
                 /Users/j/.heroku/client/vendor/gems/rest-client-1.6.7/lib/restclient/net_http_ext.rb:51:in `request'
                 /usr/local/heroku/ruby/lib/ruby/1.9.1/net/http.rb:1286:in `block in request'
                 /usr/local/heroku/ruby/lib/ruby/1.9.1/net/http.rb:745:in `start'
                 /usr/local/heroku/ruby/lib/ruby/1.9.1/net/http.rb:1284:in `request'
                 /Users/j/.heroku/client/vendor/gems/rest-client-1.6.7/lib/restclient/net_http_ext.rb:51:in `request'
                 /Users/j/.heroku/plugins/heroku-anvil/vendor/anvil/lib/anvil/manifest.rb:75:in `build'
                 /Users/j/.heroku/plugins/heroku-anvil/vendor/anvil/lib/anvil/engine.rb:40:in `build'
                 /Users/j/.heroku/plugins/heroku-anvil/lib/anvil/heroku/command/build.rb:44:in `index'
                 /Users/j/.heroku/client/lib/heroku/command.rb:218:in `run'
                 /Users/j/.heroku/client/lib/heroku/cli.rb:37:in `start'
                 /usr/local/heroku/bin/heroku:24:in `<main>'

    Command:     heroku build -r -b https://github.com/begriffs/heroku-buildpack-ghc.git
    Plugins:     heroku-anvil
                 heroku-pg-transfer

    Version:     heroku-toolbelt/3.8.1 (x86_64-darwin10.8.0) ruby/1.9.3


real    187m58.519s
user    0m3.782s
sys 0m0.920s
```
